### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Monokai theme for Visual Studio 2015
 Fork of https://github.com/mmonteleone/monokai-vs but with changes for Visual Studio 2015
 
-#Features
+# Features
 * As close as possible to Monokai
 * C#, XAML, XML, CSS, JS, HTML and CSHTML (also ASP.NET 5)
 
-#Usage
+# Usage
 Tools > Import and Export Settings > Select "Import selected environment settings" > Save current settings or just replace > Browse to the monokai_15.vssettings file downloaded/cloned from here >  Finish


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
